### PR TITLE
Add data validation to entity fields

### DIFF
--- a/src/Entity/Award.php
+++ b/src/Entity/Award.php
@@ -40,6 +40,11 @@ class Award {
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $award;
@@ -50,12 +55,22 @@ class Award {
   protected $slug;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512, nullable=true)
    */
   protected $award_funder;
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $award_url;

--- a/src/Entity/DataCollectionInstrument.php
+++ b/src/Entity/DataCollectionInstrument.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -48,16 +49,31 @@ class DataCollectionInstrument {
   protected $data_collection_instrument_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256)
    */
   protected $slug;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=256, nullable=true)
    */
   protected $url;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Notes cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=1026, nullable=true)
    */
   protected $notes;

--- a/src/Entity/DataLocation.php
+++ b/src/Entity/DataLocation.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 
 /**
@@ -36,17 +37,32 @@ class DataLocation {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Data location title cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256)
    */
   protected $data_location;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Dataset location content cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028,nullable=true)
    */
   protected $location_content;
 
   /**
-   * @ORM\Column(type="string",length=1028)
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Enter a valid URL without html or script tags"
+   * )
+   * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $data_access_url;
 
@@ -92,7 +108,7 @@ class DataLocation {
      */
     public function setDataAccessUrl($dataAccessUrl)
     {
-        $this->data_access_url = $dataAccessUrl;
+        $this->data_access_url = strip_tags($dataAccessUrl);
 
         return $this;
     }
@@ -161,7 +177,7 @@ class DataLocation {
      */
     public function setDataLocation($dataLocation)
     {
-        $this->data_location = $dataLocation;
+        $this->data_location = strip_tags($dataLocation);
 
         return $this;
     }
@@ -184,7 +200,7 @@ class DataLocation {
      */
     public function setLocationContent($locationContent)
     {
-        $this->location_content = $locationContent;
+        $this->location_content = strip_tags($locationContent);
 
         return $this;
     }

--- a/src/Entity/DatasetAlternateTitle.php
+++ b/src/Entity/DatasetAlternateTitle.php
@@ -75,7 +75,7 @@ class DatasetAlternateTitle {
      */
     public function setAltTitle($altTitle)
     {
-        $this->alt_title = $altTitle;
+        $this->alt_title = strip_tags($altTitle);
 
         return $this;
     }

--- a/src/Entity/DatasetFormat.php
+++ b/src/Entity/DatasetFormat.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,6 +40,11 @@ class DatasetFormat {
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Format cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $format;

--- a/src/Entity/OtherResource.php
+++ b/src/Entity/OtherResource.php
@@ -108,7 +108,7 @@ class OtherResource {
      */
     public function setResourceName($resourceName)
     {
-        $this->resource_name = $resourceName;
+        $this->resource_name = strip_tags($resourceName);
 
         return $this;
     }
@@ -131,7 +131,7 @@ class OtherResource {
      */
     public function setResourceDescription($resourceDescription)
     {
-        $this->resource_description = $resourceDescription;
+        $this->resource_description = strip_tags($resourceDescription);
 
         return $this;
     }
@@ -154,7 +154,7 @@ class OtherResource {
      */
     public function setResourceUrl($resourceUrl)
     {
-        $this->resource_url = $resourceUrl;
+        $this->resource_url = strip_tags($resourceUrl);
 
         return $this;
     }

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -30,7 +30,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @ORM\Entity
  * @ORM\Table(name="person")
  * @UniqueEntity("kid")
- * @UniqueEntity("slug")
+ * @UniqueEntity("full_name")
  */
 class Person {
   /**
@@ -41,12 +41,12 @@ class Person {
   protected $id;
 
   /**
-   * @ORM\Column(type="string",length=128)
+   * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $full_name;
 
   /**
-   * @ORM\Column(type="string",length=128, unique=true)
+   * @ORM\Column(type="string",length=128)
    */
   protected $slug;
 
@@ -85,11 +85,17 @@ class Person {
    */
   protected $email;
 
-  
+
+  /**
+   * @ORM\Column(type="boolean", options={"default"=false}, nullable=true)
+   */
+  protected $works_here;
+
+
   /**
    * @ORM\OneToMany(targetEntity="PersonAssociation", mappedBy="person")
    */
-  protected $dataset_associations;
+  protected $datasetAssociations;
 
 
   /**
@@ -127,7 +133,7 @@ class Person {
      */
     public function setFullName($fullName)
     {
-        $this->full_name = $fullName;
+        $this->full_name = strip_tags($fullName);
 
         return $this;
     }
@@ -150,7 +156,7 @@ class Person {
      */
     public function setLastName($lastName)
     {
-        $this->last_name = $lastName;
+        $this->last_name = strip_tags($lastName);
 
         return $this;
     }
@@ -173,7 +179,7 @@ class Person {
      */
     public function setFirstName($firstName)
     {
-        $this->first_name = $firstName;
+        $this->first_name = strip_tags($firstName);
 
         return $this;
     }
@@ -219,7 +225,7 @@ class Person {
      */
     public function setBioUrl($bioUrl)
     {
-        $this->bio_url = $bioUrl;
+        $this->bio_url = strip_tags($bioUrl);
 
         return $this;
     }
@@ -243,7 +249,7 @@ class Person {
      */
     public function setEmail($email)
     {
-        $this->email = $email;
+        $this->email = strip_tags($email);
 
         return $this;
     }
@@ -305,6 +311,32 @@ class Person {
         return $this->orcid_id;
     }
 
+
+    /**
+     * Set works_here
+     *
+     * @param string $worksHere
+     * @return Person
+     */
+    public function setWorksHere($worksHere)
+    {
+        $this->works_here = $worksHere;
+
+        return $this;
+    }
+
+
+    /**
+     * Get works_here
+     *
+     * @return string 
+     */
+    public function getWorksHere()
+    {
+        return $this->works_here;
+    }
+
+
     public function getDatasetAssociations()
     {
       return $this->datasetAssociations->toArray();
@@ -349,7 +381,8 @@ class Person {
         'first_name'=>$this->first_name,
         'orcid_id'=>$this->orcid_id,
         'bio_url'=>$this->bio_url,
-        'email'=>$this->email
+        'email'=>$this->email,
+        'works_here'=>$this->works_here
       );
     }
 }

--- a/src/Entity/Publisher.php
+++ b/src/Entity/Publisher.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,6 +40,11 @@ class Publisher {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $publisher_name;
@@ -49,6 +55,11 @@ class Publisher {
   protected $slug;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $publisher_url;

--- a/src/Entity/PublisherCategory.php
+++ b/src/Entity/PublisherCategory.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -37,6 +38,11 @@ class PublisherCategory {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Category cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256)
    */
   protected $publisher_category;

--- a/src/Entity/RelatedEquipment.php
+++ b/src/Entity/RelatedEquipment.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,16 +40,31 @@ class RelatedEquipment {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $related_equipment;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Description cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, unique=false, nullable=true)
    */
   protected $equipment_description;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, unique=false, nullable=true)
    */
   protected $equipment_url;

--- a/src/Entity/RelatedSoftware.php
+++ b/src/Entity/RelatedSoftware.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,16 +40,31 @@ class RelatedSoftware {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $software_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Description cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512, unique=false, nullable=true)
    */
   protected $software_description;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512, unique=false, nullable=true)
    */
   protected $software_url;

--- a/src/Entity/SubjectDomain.php
+++ b/src/Entity/SubjectDomain.php
@@ -90,7 +90,7 @@ class SubjectDomain {
      */
     public function setSubjectDomain($subjectDomain)
     {
-        $this->subject_domain = $subjectDomain;
+        $this->subject_domain = strip_tags($subjectDomain);
 
         return $this;
     }
@@ -113,7 +113,7 @@ class SubjectDomain {
      */
     public function setMeshCode($meshCode)
     {
-        $this->mesh_code = $meshCode;
+        $this->mesh_code = strip_tags($meshCode);
 
         return $this;
     }

--- a/src/Entity/SubjectGeographicArea.php
+++ b/src/Entity/SubjectGeographicArea.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,11 +40,21 @@ class SubjectGeographicArea {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $geographic_area_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Authority cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256, nullable=true)
    */
   protected $geographic_area_authority;

--- a/src/Entity/SubjectGeographicAreaDetail.php
+++ b/src/Entity/SubjectGeographicAreaDetail.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,11 +40,21 @@ class SubjectGeographicAreaDetail {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $geographic_area_detail_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Authority cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256, nullable=true)
    */
   protected $geographic_area_detail_authority;

--- a/src/Entity/SubjectKeyword.php
+++ b/src/Entity/SubjectKeyword.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,6 +40,11 @@ class SubjectKeyword {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Keywords cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $keyword;
@@ -68,6 +74,7 @@ class SubjectKeyword {
   public function getDisplayName() {
     return $this->keyword;
   }
+
 
     /**
      * Get id
@@ -123,6 +130,31 @@ class SubjectKeyword {
     public function getMeshCode()
     {
         return $this->mesh_code;
+    }
+
+
+    /**
+     * get OncoTree Metadata
+     *
+     * @return string
+     */
+    public function getOncoTreeMetadata() {
+        $ocode = $this->keyword;
+        $api_url = "http://oncotree.mskcc.org/api/tumorTypes/search/code/{$ocode}";
+        // Read JSON file
+        if (@file_get_contents($api_url) === false) {
+            return;   
+        } else {
+            $json_data = @file_get_contents($api_url);
+            $onco_data = json_decode($json_data);
+            $returnhtml =  "<p><strong>Name:</strong> {$onco_data[0]->name}</p>";
+            $returnhtml .= "<p><strong>Main Type:</strong> {$onco_data[0]->mainType}</p>";
+            $returnhtml .= "<p><strong>Tissue:</strong> {$onco_data[0]->tissue}</p>";
+            $returnhtml .= "<p><strong>Parent:</strong> {$onco_data[0]->parent}</p>";
+            $returnhtml .= "<p><a href='http://oncotree.mskcc.org' target='_blank'>More at OncoTree</a></p>";
+            return $returnhtml;
+    
+        }
     }
 
 

--- a/src/Entity/SubjectOfStudy.php
+++ b/src/Entity/SubjectOfStudy.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,11 +40,21 @@ class SubjectOfStudy {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $subject_of_study;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, nullable=true)
    */
   protected $species;

--- a/src/Entity/SubjectPopulationAge.php
+++ b/src/Entity/SubjectPopulationAge.php
@@ -2,6 +2,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -38,6 +39,11 @@ class SubjectPopulationAge {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $age_group;


### PR DESCRIPTION
This PR adds data validation to protect the database from <script> or other tags where they are not needed. It also brings our entity schema current with the 2.8 database.