### PR TITLE
Use the new GA4 property

### DIFF
--- a/templates/analytics.html.twig
+++ b/templates/analytics.html.twig
@@ -1,10 +1,10 @@
 {# Insert your analytics code snippet here #}
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-33268644-2"></script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TCFLPYKQPY"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-33268644-2');
+  gtag('config', 'G-TCFLPYKQPY');
 </script>


### PR DESCRIPTION
This PR switches from Google Analytics Universal property (end of life on July 1, 2023) to Google Analytics 4.