### PR TITLE
Feature/index on add or update

### DIFF
--- a/src/Command/SolrReindexAllCommand.php
+++ b/src/Command/SolrReindexAllCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Dataset;
+use App\Service\SolrIndexer;
+use Throwable;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:solr:reindex-all')]
+class SolrReindexAllCommand extends Command
+{
+  public function __construct(
+    private readonly ManagerRegistry $doctrine,
+    private readonly SolrIndexer $solrIndexer
+  ) {
+    parent::__construct();
+  }
+
+  protected function configure(): void
+  {
+    $this
+      ->addOption('job-id', null, InputOption::VALUE_REQUIRED, 'Unique job id')
+      ->addOption('status-file', null, InputOption::VALUE_REQUIRED, 'Absolute path to JSON status file');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  {
+    $jobId = (string) $input->getOption('job-id');
+    $statusFile = (string) $input->getOption('status-file');
+    if ($jobId === '' || $statusFile === '') {
+      return Command::INVALID;
+    }
+
+    $datasets = $this->doctrine->getRepository(Dataset::class)->findAll();
+    $total = count($datasets);
+    $startedAt = new \DateTimeImmutable('now');
+
+    $status = [
+      'jobId' => $jobId,
+      'state' => 'running',
+      'startedAt' => $startedAt->format(DATE_ATOM),
+      'finishedAt' => null,
+      'total' => $total,
+      'processed' => 0,
+      'indexed' => 0,
+      'removed' => 0,
+      'removedStale' => 0,
+      'errors' => [],
+      'message' => 'Reindex in progress',
+    ];
+
+    $this->writeStatus($statusFile, $status);
+
+    try {
+      $dbDatasetIds = [];
+      foreach ($datasets as $dataset) {
+        if ($dataset instanceof Dataset) {
+          $dbDatasetIds[(int) $dataset->getDatasetUid()] = true;
+        }
+      }
+
+      foreach ($datasets as $dataset) {
+        if (!$dataset instanceof Dataset) {
+          continue;
+        }
+
+        try {
+          $isPublished = (bool) $dataset->getPublished();
+          $isArchived = (bool) $dataset->getArchived();
+          $this->solrIndexer->reindexDataset($dataset);
+
+          if ($isPublished && !$isArchived) {
+            $status['indexed']++;
+          } else {
+            $status['removed']++;
+          }
+        } catch (Throwable $e) {
+          $status['errors'][] = [
+            'datasetUid' => (int) $dataset->getDatasetUid(),
+            'title' => (string) $dataset->getTitle(),
+            'message' => $e->getMessage(),
+          ];
+        }
+
+        $status['processed']++;
+        $this->writeStatus($statusFile, $status);
+      }
+
+      try {
+        $solrDatasetIds = $this->solrIndexer->fetchIndexedDatasetIds();
+        foreach ($solrDatasetIds as $solrId) {
+          if (!isset($dbDatasetIds[(int) $solrId])) {
+            try {
+              $this->solrIndexer->removeDatasetFromSolr((int) $solrId);
+              $status['removedStale']++;
+            } catch (Throwable $e) {
+              $status['errors'][] = [
+                'datasetUid' => (int) $solrId,
+                'title' => 'Stale Solr document',
+                'message' => $e->getMessage(),
+              ];
+            }
+          }
+        }
+      } catch (Throwable $e) {
+        $status['errors'][] = [
+          'datasetUid' => null,
+          'title' => 'Stale-document cleanup',
+          'message' => $e->getMessage(),
+        ];
+      }
+
+      $status['state'] = 'completed';
+      $status['message'] = count($status['errors']) > 0
+        ? 'Reindex completed with errors'
+        : 'Reindex completed successfully';
+      $status['finishedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+      $this->writeStatus($statusFile, $status);
+
+      return Command::SUCCESS;
+    } catch (Throwable $e) {
+      $status['state'] = 'failed';
+      $status['finishedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+      $status['message'] = 'Reindex failed unexpectedly';
+      $status['errors'][] = [
+        'datasetUid' => null,
+        'title' => 'Fatal error',
+        'message' => $e->getMessage(),
+      ];
+      $this->writeStatus($statusFile, $status);
+
+      return Command::FAILURE;
+    }
+  }
+
+  private function writeStatus(string $statusFile, array $status): void
+  {
+    $dir = dirname($statusFile);
+    if (!is_dir($dir)) {
+      mkdir($dir, 0775, true);
+    }
+    file_put_contents($statusFile, json_encode($status, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+  }
+}

--- a/src/Controller/APIController.php
+++ b/src/Controller/APIController.php
@@ -10,7 +10,9 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use App\Form\DatasetViaApiType;
 use App\Entity\Dataset;
+use App\Service\SolrIndexer;
 use App\Utils\Slugger;
+use Throwable;
 
 
 /**
@@ -42,7 +44,10 @@ class APIController extends AbstractController
    */
   public $personEntities = ['Author', 'LocalExpert', 'CorrespondingAuthor'];
 
-  public function __construct(private readonly Security $security)
+  public function __construct(
+    private readonly Security $security,
+    private readonly SolrIndexer $solrIndexer
+  )
   {
   }
 
@@ -149,6 +154,12 @@ class APIController extends AbstractController
           $em->persist($authorship);
         }
         $em->flush();
+
+        try {
+          $this->solrIndexer->reindexDataset($dataset);
+        } catch (Throwable $e) {
+          // Keep API write successful even if Solr is temporarily unavailable.
+        }
 
         return new Response('Dataset Successfully Added', 201);
       } else {

--- a/src/Controller/AddController.php
+++ b/src/Controller/AddController.php
@@ -11,8 +11,10 @@ use App\Entity\Dataset;
 use App\Repository\DatasetRepository;
 use App\Form\DatasetAsAdminType;
 use App\Form\DatasetAsUserType;
+use App\Service\SolrIndexer;
 use App\Utils\Slugger;
 use Doctrine\ORM\EntityManagerInterface;
+use Throwable;
 
 /*
  * A controller to handle the addition of new datasets and other entities
@@ -36,8 +38,11 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class AddController extends AbstractController {
 
-  public function __construct(private readonly Security $security, EntityManagerInterface $em) {
-    $this->em = $em;
+  public function __construct(
+    private readonly Security $security,
+    private readonly SolrIndexer $solrIndexer,
+    private readonly EntityManagerInterface $em
+  ) {
   }
 
   /**
@@ -57,7 +62,7 @@ class AddController extends AbstractController {
   public function addAction(Request $request) {
     $dataset = new Dataset();
     $userIsAdmin = $this->security->isGranted('ROLE_ADMIN');
-    $datasetUid = $this->em->getRepository(Dataset::Class)
+    $datasetUid = $this->em->getRepository(Dataset::class)
                      ->getNewDatasetId();
     $dataset->setDatasetUid($datasetUid);
 
@@ -110,6 +115,7 @@ class AddController extends AbstractController {
         $this->em->persist($authorship);
       }
       $this->em->flush();
+      $this->attemptDatasetReindex($dataset);
      
       return $this->render('default/add_success.html.twig', ['adminPage'=>true, 'entityName'=>'Dataset', 'displayName'=>'Dataset', 'addedEntityName'=>$addedEntityName, 'userIsAdmin'=>$userIsAdmin, 'uid'=>$datasetUid]);
     } else {
@@ -183,6 +189,7 @@ class AddController extends AbstractController {
       
       $this->em->persist($entity);
       $this->em->flush();
+      $this->attemptRelatedEntityReindex($entity);
       
       //
       // Added, 6/28/2017, Joel Marchewka
@@ -195,6 +202,24 @@ class AddController extends AbstractController {
     return $this->render('default/'.$addTemplate, ['form' => $form->createView(), 'userIsAdmin'=>$userIsAdmin, 'displayName' => $entityTypeDisplayName, 'adminPage'=>true, 'entityName' => $entityName]);
       
   } 
+
+  private function attemptDatasetReindex(Dataset $dataset): void
+  {
+    try {
+      $this->solrIndexer->reindexDataset($dataset);
+    } catch (Throwable $e) {
+      $this->addFlash('warning', 'Saved successfully, but Solr reindex failed for this dataset.');
+    }
+  }
+
+  private function attemptRelatedEntityReindex(object $entity): void
+  {
+    try {
+      $this->solrIndexer->reindexDatasetsForEntity($entity);
+    } catch (Throwable $e) {
+      $this->addFlash('warning', 'Saved successfully, but Solr reindex failed for one or more related datasets.');
+    }
+  }
 
 
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,6 +12,8 @@ use App\Entity\SearchState;
 use App\Entity\Dataset;
 use App\Form\DatasetType;
 use App\Utils\Slugger;
+use Symfony\Component\Process\Process;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 
 /**
@@ -35,6 +38,11 @@ use App\Utils\Slugger;
  */
 class AdminController extends AbstractController
 {
+  private const SOLR_INDEX_JOBS_DIR = 'var/solr-index-jobs';
+  private const SOLR_INDEX_START_TIMEOUT_SECONDS = 20;
+
+  public function __construct(private readonly ParameterBagInterface $params) {}
+
   /**
    * Produce the main admin dashboard
    *
@@ -43,12 +51,12 @@ class AdminController extends AbstractController
    * @return Response A Response instance
    */
   #[Route(path: '/dashboard', name: 'admin_panel')]
-  public function adminAction(Request $request) {
-    return $this->render('default/admin-home.html.twig',['adminPage'=>true]);
-    
+  public function adminAction(Request $request)
+  {
+    return $this->render('default/admin-home.html.twig', ['adminPage' => true]);
   }
-  
-  
+
+
   /**
    * Produce the entity management page
    *
@@ -57,11 +65,11 @@ class AdminController extends AbstractController
    * @return Response A Response instance
    */
   #[Route(path: '/manage', name: 'admin_manage')]
-  public function adminManageAction(Request $request) {
-    
+  public function adminManageAction(Request $request)
+  {
 
-    return $this->render('default/admin-manage.html.twig',['adminPage'=>true]);
-    
+
+    return $this->render('default/admin-manage.html.twig', ['adminPage' => true]);
   }
 
   /**
@@ -72,11 +80,307 @@ class AdminController extends AbstractController
    * @return Response A Response instance
    */
   #[Route(path: '/users', name: 'admin_users')]
-  public function adminUsersAction(Request $request) {
-    
+  public function adminUsersAction(Request $request)
+  {
 
-    return $this->render('default/admin-users.html.twig',['adminPage'=>true]);
-    
+
+    return $this->render('default/admin-users.html.twig', ['adminPage' => true]);
   }
-  
+
+  #[Route(path: '/admin/solr-index', name: 'admin_solr_index', methods: ['GET'])]
+  public function solrIndexAction(): Response
+  {
+    $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+    $jobsDir = $this->getSolrJobsDir();
+    $latestJobId = $this->findLatestJobId($jobsDir);
+
+    return $this->render('default/admin-solr-index.html.twig', [
+      'adminPage' => true,
+      'latestJobId' => $latestJobId,
+      'latestStatusUrl' => $latestJobId ? $this->generateUrl('admin_solr_index_status', ['jobId' => $latestJobId]) : null,
+      'logUrlTemplate' => $this->generateUrl('admin_solr_index_log', ['jobId' => 'JOB_ID']),
+    ]);
+  }
+
+  #[Route(path: '/admin/solr-index/start', name: 'admin_solr_index_start', methods: ['POST'])]
+  public function startSolrIndexAction(Request $request): JsonResponse
+  {
+    $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+    $csrfToken = (string) $request->request->get('_token', '');
+    if (!$this->isCsrfTokenValid('admin-solr-index', $csrfToken)) {
+      return new JsonResponse(['error' => 'Invalid CSRF token'], 400);
+    }
+
+    $projectDir = rtrim((string) $this->params->get('kernel.project_dir'), '/');
+    $jobsDir = $this->getSolrJobsDir();
+    if (!is_dir($jobsDir)) {
+      mkdir($jobsDir, 0775, true);
+    }
+
+    $runningJobs = glob($jobsDir . '/job-*.json') ?: [];
+    foreach ($runningJobs as $jobFile) {
+      $data = json_decode((string) @file_get_contents($jobFile), true);
+      if (!is_array($data)) {
+        continue;
+      }
+
+      if (($data['state'] ?? '') === 'starting' && $this->isStartTimedOut($data)) {
+        $data['state'] = 'failed';
+        $data['finishedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+        $data['message'] = 'Worker startup timed out before progress was reported.';
+        $data['errors'][] = [
+          'datasetUid' => null,
+          'title' => 'Job monitor',
+          'message' => 'Worker startup timed out before progress was reported.',
+        ];
+        $this->writeStatusFile($jobFile, $data);
+      }
+
+      if (($data['state'] ?? '') === 'running' || ($data['state'] ?? '') === 'starting') {
+        $existingJobId = (string) ($data['jobId'] ?? '');
+        return new JsonResponse([
+          'error' => 'A reindex job is already running.',
+          'jobId' => $existingJobId !== '' ? $existingJobId : null,
+          'statusUrl' => $existingJobId !== '' ? $this->generateUrl('admin_solr_index_status', ['jobId' => $existingJobId]) : null,
+        ], 409);
+      }
+    }
+
+    $jobId = bin2hex(random_bytes(8));
+    $statusFile = $jobsDir . '/job-' . $jobId . '.json';
+    file_put_contents($statusFile, json_encode([
+      'jobId' => $jobId,
+      'state' => 'starting',
+      'startedAt' => (new \DateTimeImmutable('now'))->format(DATE_ATOM),
+      'message' => 'Starting reindex job',
+      'total' => 0,
+      'processed' => 0,
+      'indexed' => 0,
+      'removed' => 0,
+      'removedStale' => 0,
+      'pid' => null,
+      'errors' => [],
+    ], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+    $console = $projectDir . '/bin/console';
+    $logFile = $jobsDir . '/job-' . $jobId . '.log';
+    $phpExecutable = 'php';
+
+    // Detach worker from web request lifecycle; write stdout/stderr to per-job log file.
+    $launchCmd = sprintf(
+      'nohup %s %s app:solr:reindex-all --job-id=%s --status-file=%s >> %s 2>&1 & echo $!',
+      escapeshellarg($phpExecutable),
+      escapeshellarg($console),
+      escapeshellarg($jobId),
+      escapeshellarg($statusFile),
+      escapeshellarg($logFile)
+    );
+    $launcher = Process::fromShellCommandline($launchCmd, $projectDir);
+    $launcher->setTimeout(15);
+    $launcher->run();
+
+    $launchedPid = (int) trim($launcher->getOutput());
+    $statusData = [
+      'jobId' => $jobId,
+      'state' => 'running',
+      'startedAt' => (new \DateTimeImmutable('now'))->format(DATE_ATOM),
+      'finishedAt' => null,
+      'message' => 'Reindex worker started',
+      'total' => 0,
+      'processed' => 0,
+      'indexed' => 0,
+      'removed' => 0,
+      'removedStale' => 0,
+      'pid' => $launchedPid > 0 ? $launchedPid : null,
+      'errors' => [],
+    ];
+    $this->writeStatusFile($statusFile, $statusData);
+
+    usleep(300000);
+    if (!$launcher->isSuccessful() || $launchedPid <= 0 || !$this->isPidRunning($launchedPid)) {
+      $startupError = trim($launcher->getErrorOutput() . "\n" . $launcher->getOutput());
+      if ($startupError === '') {
+        $startupError = 'Detached reindex worker failed to start.';
+      }
+
+      file_put_contents($logFile, $startupError . "\n", FILE_APPEND);
+      $failed = $this->readStatusFile($statusFile) ?? $statusData;
+      $failed['state'] = 'failed';
+      $failed['finishedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+      $failed['message'] = 'Failed to start reindex worker';
+      $failed['errors'][] = [
+        'datasetUid' => null,
+        'title' => 'Worker startup',
+        'message' => $startupError,
+      ];
+      $this->writeStatusFile($statusFile, $failed);
+    }
+
+    return new JsonResponse([
+      'jobId' => $jobId,
+      'statusUrl' => $this->generateUrl('admin_solr_index_status', ['jobId' => $jobId]),
+    ]);
+  }
+
+  #[Route(path: '/admin/solr-index/status/{jobId}', name: 'admin_solr_index_status', methods: ['GET'])]
+  public function solrIndexStatusAction(string $jobId): JsonResponse
+  {
+    $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+    $safeJobId = preg_replace('/[^a-f0-9]/i', '', $jobId);
+    $statusFile = $this->getSolrJobsDir() . '/job-' . $safeJobId . '.json';
+    if (!is_file($statusFile)) {
+      return new JsonResponse(['error' => 'Job not found'], 404);
+    }
+
+    $data = json_decode((string) file_get_contents($statusFile), true);
+    if (!is_array($data)) {
+      return new JsonResponse(['error' => 'Invalid status payload'], 500);
+    }
+
+    if (($data['state'] ?? '') === 'starting' && $this->isStartTimedOut($data)) {
+      $data['state'] = 'failed';
+      $data['finishedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+      $data['message'] = 'Worker startup timed out before progress was reported.';
+      $data['errors'][] = [
+        'datasetUid' => null,
+        'title' => 'Job monitor',
+        'message' => 'Worker startup timed out before progress was reported.',
+      ];
+      $this->writeStatusFile($statusFile, $data);
+    }
+
+    if (($data['state'] ?? '') === 'running' && isset($data['pid']) && (int) $data['pid'] > 0 && !$this->isPidRunning((int) $data['pid'])) {
+      $data['state'] = 'failed';
+      $data['finishedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+      $data['message'] = 'Worker process is no longer running before completion.';
+      $data['errors'][] = [
+        'datasetUid' => null,
+        'title' => 'Job monitor',
+        'message' => 'Worker process is no longer running before completion.',
+      ];
+      $this->writeStatusFile($statusFile, $data);
+    }
+
+    $response = new JsonResponse($data);
+    $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+    $response->headers->set('Pragma', 'no-cache');
+
+    return $response;
+  }
+
+  #[Route(path: '/admin/solr-index/log/{jobId}', name: 'admin_solr_index_log', methods: ['GET'])]
+  public function solrIndexLogAction(string $jobId): JsonResponse
+  {
+    $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+    $safeJobId = preg_replace('/[^a-f0-9]/i', '', $jobId);
+    $logFile = $this->getSolrJobsDir() . '/job-' . $safeJobId . '.log';
+    if (!is_file($logFile)) {
+      $response = new JsonResponse([
+        'jobId' => $safeJobId,
+        'logTail' => '',
+      ]);
+      $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+      $response->headers->set('Pragma', 'no-cache');
+
+      return $response;
+    }
+
+    $response = new JsonResponse([
+      'jobId' => $safeJobId,
+      'logTail' => $this->readLogTail($logFile, 200),
+    ]);
+    $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+    $response->headers->set('Pragma', 'no-cache');
+
+    return $response;
+  }
+
+  private function getSolrJobsDir(): string
+  {
+    $projectDir = rtrim((string) $this->params->get('kernel.project_dir'), '/');
+    return $projectDir . '/' . self::SOLR_INDEX_JOBS_DIR;
+  }
+
+  private function findLatestJobId(string $jobsDir): ?string
+  {
+    $statusFiles = glob($jobsDir . '/job-*.json') ?: [];
+    if (count($statusFiles) === 0) {
+      return null;
+    }
+
+    usort($statusFiles, static function (string $a, string $b): int {
+      return filemtime($b) <=> filemtime($a);
+    });
+
+    $latest = basename($statusFiles[0]);
+    if (preg_match('/^job-([a-f0-9]+)\.json$/i', $latest, $matches)) {
+      return $matches[1];
+    }
+
+    return null;
+  }
+
+  private function readLogTail(string $logFile, int $maxLines): string
+  {
+    $lines = @file($logFile, FILE_IGNORE_NEW_LINES);
+    if ($lines === false || count($lines) === 0) {
+      return '';
+    }
+
+    $tail = array_slice($lines, -1 * max(1, $maxLines));
+    return implode("\n", $tail);
+  }
+
+  private function writeStatusFile(string $statusFile, array $data): void
+  {
+    file_put_contents($statusFile, json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+  }
+
+  private function readStatusFile(string $statusFile): ?array
+  {
+    $raw = @file_get_contents($statusFile);
+    if ($raw === false || $raw === '') {
+      return null;
+    }
+
+    $data = json_decode($raw, true);
+    return is_array($data) ? $data : null;
+  }
+
+  private function isStartTimedOut(array $data): bool
+  {
+    $startedAt = $data['startedAt'] ?? null;
+    if (!is_string($startedAt) || $startedAt === '') {
+      return true;
+    }
+
+    try {
+      $started = new \DateTimeImmutable($startedAt);
+    } catch (\Throwable $e) {
+      return true;
+    }
+
+    $threshold = (new \DateTimeImmutable('now'))->modify('-' . self::SOLR_INDEX_START_TIMEOUT_SECONDS . ' seconds');
+    return $started < $threshold;
+  }
+
+  private function isPidRunning(int $pid): bool
+  {
+    if ($pid <= 0) {
+      return false;
+    }
+
+    if (function_exists('posix_kill')) {
+      return @posix_kill($pid, 0);
+    }
+
+    $probe = new Process(['ps', '-p', (string) $pid, '-o', 'pid=']);
+    $probe->setTimeout(2);
+    $probe->run();
+    return $probe->isSuccessful() && trim($probe->getOutput()) !== '';
+  }
 }

--- a/src/Controller/UpdateController.php
+++ b/src/Controller/UpdateController.php
@@ -11,7 +11,9 @@ use App\Entity\Dataset;
 use App\Form\DatasetAsUserType;
 use App\Form\DatasetAsAdminType;
 use App\Form\UserType;
+use App\Service\SolrIndexer;
 use App\Utils\Slugger;
+use Throwable;
 
 
 /**
@@ -36,7 +38,10 @@ use App\Utils\Slugger;
  */
 class UpdateController extends AbstractController {
 
-  public function __construct(private readonly Security $security)
+  public function __construct(
+    private readonly Security $security,
+    private readonly SolrIndexer $solrIndexer
+  )
   {
   }
 
@@ -89,6 +94,7 @@ class UpdateController extends AbstractController {
       }
       $thisEntity->setDateUpdated(new \DateTime("now"));
       $em->flush();
+      $this->attemptDatasetReindex($thisEntity);
       return $this->render('default/update_success.html.twig', ['adminPage'       => true, 'displayName'     => 'Dataset', 'entityName'      => 'Dataset', 'addedEntityName' => $addedEntityName, 'uid'             => $uid, 'newSlug'         => $newSlug]);
     } else {
       $formToRender = $userIsAdmin ? 'default/update_dataset_admin.html.twig' : 'default/update_dataset_user.html.twig';
@@ -192,10 +198,29 @@ class UpdateController extends AbstractController {
         $thisEntity->setDateUpdated(new \DateTime("now"));
       }
       $em->flush();
+      $this->attemptRelatedEntityReindex($thisEntity);
       return $this->render('default/update_success.html.twig', ['adminPage'=>true, 'displayName'=>$entityTypeDisplayName, 'entityName' =>$entityName, 'addedEntityName' => $addedEntityName, 'newSlug'    => $newSlug]);
 
     } else {
       return $this->render('default/update.html.twig', ['form'    => $form->createView(), 'displayName'=>$entityTypeDisplayName, 'adminPage'=>true, 'userIsAdmin'=>$userIsAdmin, 'slug'       =>$slug, 'entityName' =>$entityName]);
+    }
+  }
+
+  private function attemptDatasetReindex(Dataset $dataset): void
+  {
+    try {
+      $this->solrIndexer->reindexDataset($dataset);
+    } catch (Throwable $e) {
+      $this->addFlash('warning', 'Saved successfully, but Solr reindex failed for this dataset.');
+    }
+  }
+
+  private function attemptRelatedEntityReindex(object $entity): void
+  {
+    try {
+      $this->solrIndexer->reindexDatasetsForEntity($entity);
+    } catch (Throwable $e) {
+      $this->addFlash('warning', 'Saved successfully, but Solr reindex failed for one or more related datasets.');
     }
   }
 

--- a/src/Service/SolrIndexer.php
+++ b/src/Service/SolrIndexer.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Dataset;
+use DateTimeInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class SolrIndexer
+{
+  public function __construct(
+    private readonly HttpClientInterface $httpClient,
+    private readonly ParameterBagInterface $params
+  ) {}
+
+  public function reindexDataset(Dataset $dataset): void
+  {
+    $datasetUid = (int) $dataset->getDatasetUid();
+
+    // Keep Solr in sync with published/non-archived state.
+    if (!$dataset->getPublished() || $dataset->getArchived()) {
+      $this->removeDatasetFromSolr($datasetUid);
+      return;
+    }
+
+    $doc = $this->normalizeSolrDocument($dataset->serializeForSolr());
+    $payload = json_encode($doc, JSON_THROW_ON_ERROR);
+
+    $this->httpClient->request('POST', $this->getSolrJsonDocsUpdateUrl(), [
+      'headers' => [
+        'Content-Type' => 'application/json',
+      ],
+      'body' => $payload,
+    ]);
+  }
+
+  public function reindexDatasetsForEntity(object $entity): int
+  {
+    $datasets = $this->collectAffectedDatasets($entity);
+
+    foreach ($datasets as $dataset) {
+      $this->reindexDataset($dataset);
+    }
+
+    return count($datasets);
+  }
+
+  public function removeDatasetFromSolr(int $datasetUid): void
+  {
+    $payload = json_encode(['delete' => ['id' => $datasetUid]], JSON_THROW_ON_ERROR);
+
+    $this->httpClient->request('POST', $this->getSolrUpdateUrl(), [
+      'headers' => [
+        'Content-Type' => 'application/json',
+      ],
+      'body' => $payload,
+    ]);
+  }
+
+  private function collectAffectedDatasets(object $entity): array
+  {
+    $byUid = [];
+
+    if ($entity instanceof Dataset) {
+      $byUid[(int) $entity->getDatasetUid()] = $entity;
+      return array_values($byUid);
+    }
+
+    if (method_exists($entity, 'getDatasets')) {
+      foreach ($entity->getDatasets() as $dataset) {
+        if ($dataset instanceof Dataset) {
+          $byUid[(int) $dataset->getDatasetUid()] = $dataset;
+        }
+      }
+    }
+
+    if (method_exists($entity, 'getDatasetAssociations')) {
+      foreach ($entity->getDatasetAssociations() as $association) {
+        if (method_exists($association, 'getDataset')) {
+          $dataset = $association->getDataset();
+          if ($dataset instanceof Dataset) {
+            $byUid[(int) $dataset->getDatasetUid()] = $dataset;
+          }
+        }
+      }
+    }
+
+    if (method_exists($entity, 'getDataset')) {
+      $dataset = $entity->getDataset();
+      if ($dataset instanceof Dataset) {
+        $byUid[(int) $dataset->getDatasetUid()] = $dataset;
+      }
+    }
+
+    return array_values($byUid);
+  }
+
+  private function normalizeSolrDocument(array $doc): array
+  {
+    if (!empty($doc['dataset_start_date']) && !empty($doc['dataset_end_date'])) {
+      $startDate = (string) $doc['dataset_start_date'];
+      $endDate = (string) $doc['dataset_end_date'];
+      $endYear = ($endDate === 'Present') ? (int) date('Y') + 1 : (int) $endDate;
+      $startYear = (int) $startDate;
+
+      if ($startYear > 0 && $endYear >= $startYear) {
+        $doc['dataset_years'] = [];
+        for ($year = $startYear; $year <= $endYear; $year++) {
+          $doc['dataset_years'][] = sprintf('%d-01-01T00:00:00Z', $year);
+        }
+      }
+    }
+
+    foreach ($doc as $field => $value) {
+      if ($value instanceof DateTimeInterface) {
+        $doc[$field] = $value->format('Y-m-d\\T00:00:00\\Z');
+        continue;
+      }
+
+      if ($value === null) {
+        $doc[$field] = '';
+      }
+    }
+
+    return $doc;
+  }
+
+  private function getSolrCoreBaseUrl(): string
+  {
+    $solrCoreUrl = $this->params->get('solrsearchr_server');
+    return rtrim((string) $solrCoreUrl, '/');
+  }
+
+  private function getSolrJsonDocsUpdateUrl(): string
+  {
+    return $this->getSolrCoreBaseUrl() . '/update/json/docs?commit=true&overwrite=true';
+  }
+
+  private function getSolrUpdateUrl(): string
+  {
+    return $this->getSolrCoreBaseUrl() . '/update?commit=true';
+  }
+}

--- a/src/Service/SolrIndexer.php
+++ b/src/Service/SolrIndexer.php
@@ -58,6 +58,32 @@ class SolrIndexer
     ]);
   }
 
+  /**
+   * @return int[]
+   */
+  public function fetchIndexedDatasetIds(): array
+  {
+    $response = $this->httpClient->request('GET', $this->getSolrSelectUrl(), [
+      'query' => [
+        'q' => '*:*',
+        'fl' => 'id',
+        'rows' => 100000,
+        'wt' => 'json',
+      ],
+    ]);
+
+    $payload = $response->toArray(false);
+    $docs = $payload['response']['docs'] ?? [];
+    $ids = [];
+    foreach ($docs as $doc) {
+      if (isset($doc['id'])) {
+        $ids[] = (int) $doc['id'];
+      }
+    }
+
+    return $ids;
+  }
+
   private function collectAffectedDatasets(object $entity): array
   {
     $byUid = [];
@@ -140,5 +166,10 @@ class SolrIndexer
   private function getSolrUpdateUrl(): string
   {
     return $this->getSolrCoreBaseUrl() . '/update?commit=true';
+  }
+
+  private function getSolrSelectUrl(): string
+  {
+    return $this->getSolrCoreBaseUrl() . '/select';
   }
 }

--- a/templates/default/_admin-sidebar-menu.html.twig
+++ b/templates/default/_admin-sidebar-menu.html.twig
@@ -26,6 +26,9 @@
         <li class="nav-item {% if app.request.get('_route') == 'admin_users' or 'update/User' in app.request.requestUri %}{% endif %}" role="presentation">
           <a class="nav-link fw-normal" href="{{ path('admin_users') }}">Manage Website Users</a>
         </li>
+        <li class="nav-item {% if app.request.get('_route') == 'admin_solr_index' %}{% endif %}" role="presentation">
+          <a class="nav-link fw-normal" href="{{ path('admin_solr_index') }}">Reindex All Datasets</a>
+        </li>
         <div class="spacer25"></div>
         <li class="nav-item {% if 'update/ArchivedDatasets' in app.request.requestUri %}{% endif %}" role="presentation">
           <a class="nav-link fw-normal" href="{{ path('update_entity', { entityName: 'ArchivedDatasets' }) }}">View Archived Datasets</a>

--- a/templates/default/admin-solr-index.html.twig
+++ b/templates/default/admin-solr-index.html.twig
@@ -1,0 +1,323 @@
+{% extends 'base.html.twig' %}
+
+{% block page_title %}
+  <title>Solr Index</title>
+{% endblock %}
+
+{% block content %}
+  <div class="container mb-5">
+    <div class="d-flex flex-wrap justify-content-between align-items-start">
+      {% include 'default/_admin-sidebar-menu.html.twig' %}
+      <div class="col-12 col-md-9">
+        <div class="page-header">
+          <h1>Solr Index</h1>
+        </div>
+        <p>Trigger a full reindex of all datasets. Progress and errors will be shown below while indexing runs.</p>
+
+        <div class="spacer25"></div>
+
+        <form id="solr-reindex-form" class="mb-3">
+          <input type="hidden" name="_token" value="{{ csrf_token('admin-solr-index') }}" />
+          <button id="start-reindex-btn" type="submit" class="btn btn-primary">Start Full Reindex</button>
+        </form>
+
+        <div id="solr-status-card" class="card d-none">
+          <div class="card-body">
+            <h5 class="card-title">Indexing Status</h5>
+            <p id="solr-status-text" class="mb-2">Waiting...</p>
+
+            <div class="progress mb-3" role="progressbar" aria-label="Reindex progress">
+              <div id="solr-progress-bar" class="progress-bar" style="width: 0%">0%</div>
+            </div>
+
+            <div class="row g-2 mb-3">
+              <div class="col-6 col-md-3">
+                <strong>Total:</strong> <span id="solr-total">0</span>
+              </div>
+              <div class="col-6 col-md-3">
+                <strong>Processed:</strong> <span id="solr-processed">0</span>
+              </div>
+              <div class="col-6 col-md-3">
+                <strong>Indexed:</strong> <span id="solr-indexed">0</span>
+              </div>
+              <div class="col-6 col-md-3">
+                <strong>Removed:</strong> <span id="solr-removed">0</span>
+              </div>
+              <div class="col-6 col-md-3">
+                <strong>Removed stale:</strong> <span id="solr-removed-stale">0</span>
+              </div>
+            </div>
+
+            <div>
+              <h6>Errors</h6>
+              <ul id="solr-errors" class="mb-0"></ul>
+            </div>
+          </div>
+        </div>
+
+        <div id="solr-log-card" class="card mt-3 d-none">
+          <div class="card-body">
+            <h5 class="card-title">Latest Job Log</h5>
+            <p class="mb-2">
+              <strong>Job:</strong> <span id="solr-log-job-id">None</span>
+            </p>
+            <div class="mb-2 d-flex align-items-center gap-2">
+              <button id="copy-solr-log-btn" type="button" class="btn btn-outline-secondary btn-sm">Copy Log</button>
+              <span id="copy-solr-log-status" class="small text-muted"></span>
+            </div>
+            <pre id="solr-job-log" class="mb-0" style="max-height: 320px; overflow: auto; white-space: pre-wrap;">No log output yet.</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block page_scripts %}
+  <script>
+    ;(function () {
+      var form = document.getElementById('solr-reindex-form')
+      var startBtn = document.getElementById('start-reindex-btn')
+      var statusCard = document.getElementById('solr-status-card')
+      var statusText = document.getElementById('solr-status-text')
+      var progressBar = document.getElementById('solr-progress-bar')
+      var totalEl = document.getElementById('solr-total')
+      var processedEl = document.getElementById('solr-processed')
+      var indexedEl = document.getElementById('solr-indexed')
+      var removedEl = document.getElementById('solr-removed')
+      var removedStaleEl = document.getElementById('solr-removed-stale')
+      var errorsEl = document.getElementById('solr-errors')
+      var logCard = document.getElementById('solr-log-card')
+      var logJobIdEl = document.getElementById('solr-log-job-id')
+      var logContentEl = document.getElementById('solr-job-log')
+      var copyLogBtn = document.getElementById('copy-solr-log-btn')
+      var copyLogStatusEl = document.getElementById('copy-solr-log-status')
+    
+      var latestJobId = "{{ latestJobId|default('') }}"
+      var latestStatusUrl = "{{ latestStatusUrl|default('') }}"
+      var logUrlTemplate = '{{ logUrlTemplate }}'
+      var currentJobId = ''
+    
+      var pollTimer = null
+    
+      function setCopyStatus(message) {
+        copyLogStatusEl.textContent = message || ''
+      }
+    
+      function copyTextToClipboard(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          return navigator.clipboard.writeText(text)
+        }
+    
+        return new Promise(function (resolve, reject) {
+          var textarea = document.createElement('textarea')
+          textarea.value = text
+          textarea.style.position = 'fixed'
+          textarea.style.left = '-9999px'
+          document.body.appendChild(textarea)
+          textarea.focus()
+          textarea.select()
+    
+          try {
+            var copied = document.execCommand('copy')
+            document.body.removeChild(textarea)
+            if (copied) {
+              resolve()
+            } else {
+              reject(new Error('Copy command failed.'))
+            }
+          } catch (error) {
+            document.body.removeChild(textarea)
+            reject(error)
+          }
+        })
+      }
+    
+      function setProgress(total, processed) {
+        var percent = total > 0 ? Math.round((processed / total) * 100) : 0
+        if (processed > 0 && total === 0) {
+          percent = 100
+        }
+        progressBar.style.width = percent + '%'
+        progressBar.textContent = percent + '%'
+      }
+    
+      function renderErrors(errors) {
+        errorsEl.innerHTML = ''
+        if (!errors || !errors.length) {
+          var li = document.createElement('li')
+          li.textContent = 'No errors'
+          errorsEl.appendChild(li)
+          return
+        }
+    
+        errors.forEach(function (err) {
+          var li = document.createElement('li')
+          var uid = err.datasetUid !== null && err.datasetUid !== undefined ? 'Dataset ' + err.datasetUid + ': ' : ''
+          li.textContent = uid + err.title + ' - ' + err.message
+          errorsEl.appendChild(li)
+        })
+      }
+    
+      function renderStatus(status) {
+        statusCard.classList.remove('d-none')
+        statusText.textContent = status.message || status.state || 'Running'
+    
+        var total = Number(status.total || 0)
+        var processed = Number(status.processed || 0)
+        totalEl.textContent = String(total)
+        processedEl.textContent = String(processed)
+        indexedEl.textContent = String(status.indexed || 0)
+        removedEl.textContent = String(status.removed || 0)
+        removedStaleEl.textContent = String(status.removedStale || 0)
+        setProgress(total, processed)
+        renderErrors(status.errors || [])
+    
+        if (status.state === 'completed' || status.state === 'failed') {
+          startBtn.disabled = false
+          if (pollTimer) {
+            clearInterval(pollTimer)
+            pollTimer = null
+          }
+        }
+      }
+    
+      function getLogUrl(jobId) {
+        return logUrlTemplate.replace('JOB_ID', encodeURIComponent(jobId))
+      }
+    
+      function setCurrentJob(jobId) {
+        currentJobId = jobId || ''
+        if (!currentJobId) {
+          return
+        }
+    
+        logCard.classList.remove('d-none')
+        logJobIdEl.textContent = currentJobId
+      }
+    
+      function pollLog(jobId) {
+        if (!jobId) {
+          return
+        }
+    
+        fetch(getLogUrl(jobId), {
+          cache: 'no-store',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        })
+          .then(function (response) {
+            if (!response.ok) {
+              return
+            }
+            return response.json()
+          })
+          .then(function (payload) {
+            if (!payload) {
+              return
+            }
+            var text = payload.logTail || 'No log output yet.'
+            logContentEl.textContent = text
+          })
+      }
+    
+      function pollStatus(statusUrl, jobId) {
+        if (jobId) {
+          setCurrentJob(jobId)
+        }
+    
+        fetch(statusUrl, {
+          cache: 'no-store',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        })
+          .then(function (response) {
+            if (!response.ok) {
+              throw new Error('Unable to fetch status (' + response.status + ')')
+            }
+            return response.json()
+          })
+          .then(function (status) {
+            renderStatus(status)
+            pollLog(currentJobId)
+          })
+          .catch(function (error) {
+            statusCard.classList.remove('d-none')
+            statusText.textContent = error.message
+          })
+      }
+    
+      form.addEventListener('submit', function (event) {
+        event.preventDefault()
+        startBtn.disabled = true
+        statusCard.classList.remove('d-none')
+        statusText.textContent = 'Starting reindex job...'
+        setProgress(0, 0)
+        renderErrors([])
+    
+        var formData = new FormData(form)
+    
+        fetch("{{ path('admin_solr_index_start') }}", {
+          method: 'POST',
+          cache: 'no-store',
+          body: formData,
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        })
+          .then(function (response) {
+            return response.json().then(function (data) {
+              return { ok: response.ok, status: response.status, data: data }
+            })
+          })
+          .then(function (result) {
+            if (!result.ok) {
+              if (result.data && result.data.statusUrl) {
+                statusText.textContent = result.data.error || 'Monitoring existing job...'
+                setCurrentJob(result.data.jobId || '')
+                pollStatus(result.data.statusUrl, currentJobId)
+                pollTimer = setInterval(function () {
+                  pollStatus(result.data.statusUrl, currentJobId)
+                }, 1500)
+                return
+              }
+              throw new Error(result.data.error || 'Failed to start job (' + result.status + ')')
+            }
+    
+            setCurrentJob(result.data.jobId || '')
+            pollStatus(result.data.statusUrl, currentJobId)
+            pollTimer = setInterval(function () {
+              pollStatus(result.data.statusUrl, currentJobId)
+            }, 1500)
+          })
+          .catch(function (error) {
+            statusText.textContent = error.message
+            startBtn.disabled = false
+          })
+      })
+    
+      if (latestJobId && latestStatusUrl) {
+        setCurrentJob(latestJobId)
+        pollStatus(latestStatusUrl, latestJobId)
+      }
+    
+      copyLogBtn.addEventListener('click', function () {
+        var text = logContentEl.textContent || ''
+        if (!text.trim()) {
+          setCopyStatus('No log text to copy.')
+          return
+        }
+    
+        copyTextToClipboard(text)
+          .then(function () {
+            setCopyStatus('Copied log to clipboard.')
+          })
+          .catch(function () {
+            setCopyStatus('Unable to copy log.')
+          })
+      })
+    })()
+  </script>
+{% endblock %}

--- a/templates/default/admin-solr-index.html.twig
+++ b/templates/default/admin-solr-index.html.twig
@@ -14,7 +14,6 @@
         </div>
         <p>Trigger a full reindex of all datasets. Progress and errors will be shown below while indexing runs.</p>
         <p class="fw-bold">Note: Do not navigate away from this page while the reindex is running.</p>
-        <p>Status definitions:</p>
         <code>
           <ul>
             <li>

--- a/templates/default/admin-solr-index.html.twig
+++ b/templates/default/admin-solr-index.html.twig
@@ -13,6 +13,27 @@
           <h1>Solr Index</h1>
         </div>
         <p>Trigger a full reindex of all datasets. Progress and errors will be shown below while indexing runs.</p>
+        <p class="fw-bold">Note: Do not navigate away from this page while the reindex is running.</p>
+        <p>Status definitions:</p>
+        <code>
+          <ul>
+            <li>
+              <strong>Total</strong>: Total number of datasets to process.
+            </li>
+            <li>
+              <strong>Processed</strong>: Number of datasets processed so far.
+            </li>
+            <li>
+              <strong>Indexed</strong>: Number of datasets successfully indexed in Solr.
+            </li>
+            <li>
+              <strong>Removed</strong>: Number of datasets removed from Solr because they are unpublished/archived.
+            </li>
+            <li>
+              <strong>Removed stale</strong>: Number of orphaned Solr documents removed that have no corresponding dataset in the database.
+            </li>
+          </ul>
+        </code>
 
         <div class="spacer25"></div>
 


### PR DESCRIPTION
This PR:

Adds a solr indexing service that:

- automatically indexes new or updated datasets
- if related entities (i.e. data type, subject domain, data collection instrument) are modified, any datasets using them should be re-indexed
- deleted items are automatically removed from the solr index

Adds an admin page to reindex all datasets in the database.
-does not index archived or unpublished datasets
-removes orphan solr datasets whose id no longer exists in the database
-shows recent log messages on the page

<img width="1043" height="508" alt="image" src="https://github.com/user-attachments/assets/39c1cbb1-d55d-4817-8f60-e3d9e534587d" />

